### PR TITLE
Implement features from issue 33

### DIFF
--- a/EatLock/EatLock/EatLockApp.swift
+++ b/EatLock/EatLock/EatLockApp.swift
@@ -35,6 +35,12 @@ struct EatLockApp: App {
                 .task {
                     // アプリ起動時にAIを初期化
                     await AIManager.shared.initialize()
+                    
+                    // アプリ起動時に通知マネージャーを初期化
+                    await NotificationManager.shared.initialize()
+                    
+                    // 通知権限を初回のみリクエスト
+                    await NotificationManager.shared.requestPermissionIfNeeded()
                 }
         }
         .modelContainer(sharedModelContainer)

--- a/EatLock/EatLock/Navigation/NavigationDestination.swift
+++ b/EatLock/EatLock/Navigation/NavigationDestination.swift
@@ -16,6 +16,7 @@ enum NavigationDestination: Hashable {
     case settings
     case statistics
     case tutorial
+    case notificationTest
 }
 
 /// NavigationDestinationのビュー生成拡張
@@ -33,6 +34,8 @@ extension NavigationDestination {
             StatisticsView()
         case .tutorial:
             TutorialView()
+        case .notificationTest:
+            NotificationTestView()
         }
     }
 }
@@ -194,18 +197,36 @@ struct LogDetailView: View {
 /// 設定画面（将来的な拡張用）
 struct SettingsView: View {
     @Environment(\.dismiss) private var dismiss
+    private let router = NavigationRouter.shared
     
     var body: some View {
-        VStack {
-            Text("設定")
-                .font(.title)
-                .padding()
+        List {
+            Section {
+                Button(action: {
+                    router.push(.notificationTest)
+                }) {
+                    HStack {
+                        Image(systemName: "bell.badge")
+                            .foregroundColor(.blue)
+                        Text("通知テスト")
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .font(.caption)
+                            .foregroundColor(.gray)
+                    }
+                }
+                .buttonStyle(PlainButtonStyle())
+            } header: {
+                Text("開発者ツール")
+            }
             
-            Text("将来的な機能拡張の準備として作成されました")
-                .font(.caption)
-                .foregroundColor(.secondary)
-            
-            Spacer()
+            Section {
+                Text("将来的な機能拡張の準備として作成されました")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            } header: {
+                Text("情報")
+            }
         }
         .navigationTitle("設定")
         .navigationBarTitleDisplayMode(.inline)

--- a/EatLock/EatLock/Navigation/NavigationRouter.swift
+++ b/EatLock/EatLock/Navigation/NavigationRouter.swift
@@ -230,6 +230,8 @@ extension NavigationDestination: Identifiable {
             return "statistics"
         case .tutorial:
             return "tutorial"
+        case .notificationTest:
+            return "notificationTest"
         }
     }
 }

--- a/EatLock/EatLock/NotificationManager.swift
+++ b/EatLock/EatLock/NotificationManager.swift
@@ -1,0 +1,340 @@
+//
+//  NotificationManager.swift
+//  EatLock
+//
+//  Created by Issue #33 on 2025/07/04.
+//
+
+import Foundation
+import UserNotifications
+import SwiftUI
+import os.log
+
+/// 通知権限管理とローカル通知機能を提供するマネージャークラス
+@MainActor
+final class NotificationManager: ObservableObject {
+    
+    // MARK: - Properties
+    
+    static let shared = NotificationManager()
+    
+    @Published var authorizationStatus: UNAuthorizationStatus = .notDetermined
+    @Published var isInitialized = false
+    @Published var lastError: NotificationError?
+    
+    private let logger = Logger(subsystem: "com.eatlock.notification", category: "NotificationManager")
+    private let notificationCenter = UNUserNotificationCenter.current()
+    
+    // UserDefaults キー
+    private let hasRequestedPermissionKey = "EatLock_HasRequestedNotificationPermission"
+    private let permissionRequestDateKey = "EatLock_NotificationPermissionRequestDate"
+    
+    // MARK: - Initialization
+    
+    private init() {
+        logger.info("NotificationManager initialized")
+        setupNotificationDelegate()
+    }
+    
+    // MARK: - Public Methods
+    
+    /// 通知マネージャーを初期化
+    func initialize() async {
+        guard !isInitialized else {
+            logger.info("NotificationManager already initialized")
+            return
+        }
+        
+        logger.info("Starting NotificationManager initialization")
+        
+        // 現在の権限状態を取得
+        await updateAuthorizationStatus()
+        
+        // 通知カテゴリーを設定
+        setupNotificationCategories()
+        
+        isInitialized = true
+        logger.info("NotificationManager initialization completed")
+    }
+    
+    /// 通知権限をリクエスト（初回のみ）
+    func requestPermissionIfNeeded() async {
+        // 既にリクエスト済みかチェック
+        if hasRequestedPermission() {
+            logger.info("Notification permission already requested, skipping")
+            return
+        }
+        
+        // 現在の権限状態を確認
+        await updateAuthorizationStatus()
+        
+        // 既に権限が決定している場合はスキップ
+        if authorizationStatus != .notDetermined {
+            logger.info("Notification permission already determined: \(authorizationStatus)")
+            markPermissionAsRequested()
+            return
+        }
+        
+        // 権限をリクエスト
+        await requestPermission()
+    }
+    
+    /// 通知権限をリクエスト
+    func requestPermission() async {
+        logger.info("Requesting notification permission")
+        
+        do {
+            let granted = try await notificationCenter.requestAuthorization(
+                options: [.alert, .badge, .sound]
+            )
+            
+            await updateAuthorizationStatus()
+            markPermissionAsRequested()
+            
+            if granted {
+                logger.info("Notification permission granted")
+            } else {
+                logger.info("Notification permission denied")
+            }
+            
+        } catch {
+            logger.error("Failed to request notification permission: \(error.localizedDescription)")
+            lastError = .permissionRequestFailed(error)
+        }
+    }
+    
+    /// テスト用ローカル通知を即時発火
+    func scheduleTestNotification() async {
+        guard await checkPermission() else {
+            logger.warning("Cannot schedule test notification: permission not granted")
+            return
+        }
+        
+        logger.info("Scheduling test notification")
+        
+        let content = UNMutableNotificationContent()
+        content.title = "EatLock テスト通知"
+        content.body = "通知機能が正常に動作しています！"
+        content.sound = .default
+        content.badge = 1
+        
+        // 即時発火（1秒後）
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)
+        let request = UNNotificationRequest(
+            identifier: "test_notification_\(Date().timeIntervalSince1970)",
+            content: content,
+            trigger: trigger
+        )
+        
+        do {
+            try await notificationCenter.add(request)
+            logger.info("Test notification scheduled successfully")
+        } catch {
+            logger.error("Failed to schedule test notification: \(error.localizedDescription)")
+            lastError = .schedulingFailed(error)
+        }
+    }
+    
+    /// 習慣化サポート通知をスケジュール
+    func scheduleHabitReminderNotification(at time: DateComponents) async {
+        guard await checkPermission() else {
+            logger.warning("Cannot schedule habit reminder: permission not granted")
+            return
+        }
+        
+        logger.info("Scheduling habit reminder notification")
+        
+        let content = UNMutableNotificationContent()
+        content.title = "EatLock 習慣化サポート"
+        content.body = "今日の行動を記録しましょう！小さな一歩が大きな変化につながります。"
+        content.sound = .default
+        content.categoryIdentifier = "HABIT_REMINDER"
+        
+        let trigger = UNCalendarNotificationTrigger(dateMatching: time, repeats: true)
+        let request = UNNotificationRequest(
+            identifier: "habit_reminder",
+            content: content,
+            trigger: trigger
+        )
+        
+        do {
+            try await notificationCenter.add(request)
+            logger.info("Habit reminder notification scheduled successfully")
+        } catch {
+            logger.error("Failed to schedule habit reminder: \(error.localizedDescription)")
+            lastError = .schedulingFailed(error)
+        }
+    }
+    
+    /// 全ての通知を削除
+    func removeAllNotifications() {
+        logger.info("Removing all notifications")
+        notificationCenter.removeAllPendingNotificationRequests()
+        notificationCenter.removeAllDeliveredNotifications()
+    }
+    
+    /// 特定のカテゴリの通知を削除
+    func removeNotifications(withCategory category: String) {
+        logger.info("Removing notifications for category: \(category)")
+        notificationCenter.getPendingNotificationRequests { requests in
+            let identifiers = requests
+                .filter { $0.content.categoryIdentifier == category }
+                .map { $0.identifier }
+            
+            self.notificationCenter.removePendingNotificationRequests(withIdentifiers: identifiers)
+        }
+    }
+    
+    // MARK: - Private Methods
+    
+    /// 通知権限の状態を更新
+    private func updateAuthorizationStatus() async {
+        let settings = await notificationCenter.notificationSettings()
+        authorizationStatus = settings.authorizationStatus
+        logger.info("Authorization status updated: \(authorizationStatus)")
+    }
+    
+    /// 通知権限をチェック
+    private func checkPermission() async -> Bool {
+        await updateAuthorizationStatus()
+        return authorizationStatus == .authorized
+    }
+    
+    /// 通知カテゴリーを設定
+    private func setupNotificationCategories() {
+        let habitReminderCategory = UNNotificationCategory(
+            identifier: "HABIT_REMINDER",
+            actions: [],
+            intentIdentifiers: [],
+            options: .customDismissAction
+        )
+        
+        notificationCenter.setNotificationCategories([habitReminderCategory])
+        logger.info("Notification categories set up")
+    }
+    
+    /// 通知デリゲートを設定
+    private func setupNotificationDelegate() {
+        notificationCenter.delegate = NotificationDelegate.shared
+    }
+    
+    /// 権限リクエスト済みかチェック
+    private func hasRequestedPermission() -> Bool {
+        return UserDefaults.standard.bool(forKey: hasRequestedPermissionKey)
+    }
+    
+    /// 権限リクエストを記録
+    private func markPermissionAsRequested() {
+        UserDefaults.standard.set(true, forKey: hasRequestedPermissionKey)
+        UserDefaults.standard.set(Date(), forKey: permissionRequestDateKey)
+        logger.info("Permission request marked as completed")
+    }
+    
+    /// 権限リクエスト日時を取得
+    func getPermissionRequestDate() -> Date? {
+        return UserDefaults.standard.object(forKey: permissionRequestDateKey) as? Date
+    }
+    
+    /// 権限状態の詳細情報を取得
+    func getDetailedPermissionStatus() async -> NotificationPermissionStatus {
+        let settings = await notificationCenter.notificationSettings()
+        
+        return NotificationPermissionStatus(
+            authorization: settings.authorizationStatus,
+            alertSetting: settings.alertSetting,
+            badgeSetting: settings.badgeSetting,
+            soundSetting: settings.soundSetting,
+            hasRequestedPermission: hasRequestedPermission(),
+            requestDate: getPermissionRequestDate()
+        )
+    }
+}
+
+// MARK: - NotificationDelegate
+
+/// 通知デリゲート実装
+private class NotificationDelegate: NSObject, UNUserNotificationCenterDelegate {
+    static let shared = NotificationDelegate()
+    
+    private let logger = Logger(subsystem: "com.eatlock.notification", category: "NotificationDelegate")
+    
+    /// アプリがフォアグラウンドで通知を受信した時の処理
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        logger.info("Notification received in foreground: \(notification.request.identifier)")
+        
+        // フォアグラウンドでも通知を表示
+        completionHandler([.alert, .badge, .sound])
+    }
+    
+    /// 通知をタップした時の処理
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        logger.info("Notification action received: \(response.actionIdentifier)")
+        
+        // 通知に対するアクションを処理
+        handleNotificationResponse(response)
+        
+        completionHandler()
+    }
+    
+    private func handleNotificationResponse(_ response: UNNotificationResponse) {
+        let identifier = response.notification.request.identifier
+        let categoryIdentifier = response.notification.request.content.categoryIdentifier
+        
+        logger.info("Handling notification response - ID: \(identifier), Category: \(categoryIdentifier)")
+        
+        // 必要に応じて特定のアクションを実行
+        // 例: アプリ内の特定画面に遷移など
+    }
+}
+
+// MARK: - Supporting Types
+
+/// 通知権限の詳細状態
+struct NotificationPermissionStatus {
+    let authorization: UNAuthorizationStatus
+    let alertSetting: UNNotificationSetting
+    let badgeSetting: UNNotificationSetting
+    let soundSetting: UNNotificationSetting
+    let hasRequestedPermission: Bool
+    let requestDate: Date?
+    
+    var isFullyAuthorized: Bool {
+        return authorization == .authorized &&
+               alertSetting == .enabled &&
+               badgeSetting == .enabled &&
+               soundSetting == .enabled
+    }
+    
+    var canShowNotifications: Bool {
+        return authorization == .authorized
+    }
+}
+
+/// 通知関連エラー
+enum NotificationError: LocalizedError {
+    case permissionRequestFailed(Error)
+    case schedulingFailed(Error)
+    case notInitialized
+    case permissionDenied
+    
+    var errorDescription: String? {
+        switch self {
+        case .permissionRequestFailed(let error):
+            return "通知権限のリクエストに失敗しました: \(error.localizedDescription)"
+        case .schedulingFailed(let error):
+            return "通知のスケジュールに失敗しました: \(error.localizedDescription)"
+        case .notInitialized:
+            return "通知マネージャーが初期化されていません"
+        case .permissionDenied:
+            return "通知権限が拒否されています"
+        }
+    }
+}

--- a/EatLock/EatLock/Views/Components/NotificationTestView.swift
+++ b/EatLock/EatLock/Views/Components/NotificationTestView.swift
@@ -1,0 +1,297 @@
+//
+//  NotificationTestView.swift
+//  EatLock
+//
+//  Created by Issue #33 on 2025/07/04.
+//
+
+import SwiftUI
+import UserNotifications
+
+/// 通知機能をテストするためのビュー
+struct NotificationTestView: View {
+    @ObservedObject private var notificationManager = NotificationManager.shared
+    @State private var showingAlert = false
+    @State private var alertMessage = ""
+    @State private var detailStatus: NotificationPermissionStatus?
+    
+    var body: some View {
+        NavigationView {
+            List {
+                // 権限状態セクション
+                Section {
+                    VStack(alignment: .leading, spacing: 12) {
+                        HStack {
+                            Text("権限状態")
+                                .font(.headline)
+                            Spacer()
+                            StatusIndicator(status: notificationManager.authorizationStatus)
+                        }
+                        
+                        Text(statusDescription)
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    .padding(.vertical, 8)
+                } header: {
+                    Text("通知権限")
+                }
+                
+                // 詳細情報セクション
+                if let status = detailStatus {
+                    Section {
+                        VStack(alignment: .leading, spacing: 8) {
+                            DetailRow(title: "アラート", value: settingDescription(status.alertSetting))
+                            DetailRow(title: "バッジ", value: settingDescription(status.badgeSetting))
+                            DetailRow(title: "サウンド", value: settingDescription(status.soundSetting))
+                            
+                            if let requestDate = status.requestDate {
+                                DetailRow(title: "リクエスト日時", value: formatDate(requestDate))
+                            }
+                        }
+                    } header: {
+                        Text("詳細設定")
+                    }
+                }
+                
+                // アクションセクション
+                Section {
+                    VStack(spacing: 12) {
+                        // 権限リクエスト
+                        Button(action: {
+                            Task {
+                                await notificationManager.requestPermission()
+                                await updateDetailStatus()
+                            }
+                        }) {
+                            HStack {
+                                Image(systemName: "bell.badge")
+                                    .foregroundColor(.blue)
+                                Text("権限をリクエスト")
+                            }
+                        }
+                        .disabled(!canRequestPermission)
+                        
+                        // テスト通知
+                        Button(action: {
+                            Task {
+                                await notificationManager.scheduleTestNotification()
+                                showAlert(message: "テスト通知をスケジュールしました")
+                            }
+                        }) {
+                            HStack {
+                                Image(systemName: "bell.circle")
+                                    .foregroundColor(.green)
+                                Text("テスト通知を発火")
+                            }
+                        }
+                        .disabled(!canScheduleNotification)
+                        
+                        // 習慣化サポート通知
+                        Button(action: {
+                            Task {
+                                // 毎日20時に通知
+                                var dateComponents = DateComponents()
+                                dateComponents.hour = 20
+                                dateComponents.minute = 0
+                                
+                                await notificationManager.scheduleHabitReminderNotification(at: dateComponents)
+                                showAlert(message: "習慣化サポート通知をスケジュールしました（毎日20時）")
+                            }
+                        }) {
+                            HStack {
+                                Image(systemName: "clock.badge")
+                                    .foregroundColor(.orange)
+                                Text("習慣化サポート通知をスケジュール")
+                            }
+                        }
+                        .disabled(!canScheduleNotification)
+                        
+                        // 全通知削除
+                        Button(action: {
+                            notificationManager.removeAllNotifications()
+                            showAlert(message: "全ての通知を削除しました")
+                        }) {
+                            HStack {
+                                Image(systemName: "trash")
+                                    .foregroundColor(.red)
+                                Text("全ての通知を削除")
+                            }
+                        }
+                    }
+                } header: {
+                    Text("アクション")
+                }
+                
+                // エラー情報
+                if let error = notificationManager.lastError {
+                    Section {
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("エラー")
+                                .font(.headline)
+                                .foregroundColor(.red)
+                            
+                            Text(error.localizedDescription)
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                        .padding(.vertical, 8)
+                    } header: {
+                        Text("エラー情報")
+                    }
+                }
+            }
+            .navigationTitle("通知テスト")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("更新") {
+                        Task {
+                            await updateDetailStatus()
+                        }
+                    }
+                }
+            }
+            .alert("通知", isPresented: $showingAlert) {
+                Button("OK") { }
+            } message: {
+                Text(alertMessage)
+            }
+        }
+        .task {
+            await updateDetailStatus()
+        }
+    }
+    
+    // MARK: - Private Methods
+    
+    private func updateDetailStatus() async {
+        detailStatus = await notificationManager.getDetailedPermissionStatus()
+    }
+    
+    private func showAlert(message: String) {
+        alertMessage = message
+        showingAlert = true
+    }
+    
+    private func formatDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .short
+        formatter.timeStyle = .short
+        return formatter.string(from: date)
+    }
+    
+    private func settingDescription(_ setting: UNNotificationSetting) -> String {
+        switch setting {
+        case .enabled:
+            return "有効"
+        case .disabled:
+            return "無効"
+        case .notSupported:
+            return "サポート外"
+        @unknown default:
+            return "不明"
+        }
+    }
+    
+    private var statusDescription: String {
+        switch notificationManager.authorizationStatus {
+        case .notDetermined:
+            return "通知権限がまだ決定されていません。権限をリクエストしてください。"
+        case .denied:
+            return "通知権限が拒否されています。設定アプリから権限を有効にしてください。"
+        case .authorized:
+            return "通知権限が許可されています。通知を送信できます。"
+        case .provisional:
+            return "仮の通知権限が許可されています。"
+        case .ephemeral:
+            return "一時的な通知権限が許可されています。"
+        @unknown default:
+            return "不明な権限状態です。"
+        }
+    }
+    
+    private var canRequestPermission: Bool {
+        return notificationManager.authorizationStatus == .notDetermined || 
+               notificationManager.authorizationStatus == .denied
+    }
+    
+    private var canScheduleNotification: Bool {
+        return notificationManager.authorizationStatus == .authorized
+    }
+}
+
+// MARK: - Supporting Views
+
+struct StatusIndicator: View {
+    let status: UNAuthorizationStatus
+    
+    var body: some View {
+        HStack(spacing: 4) {
+            Circle()
+                .fill(color)
+                .frame(width: 10, height: 10)
+            
+            Text(text)
+                .font(.caption)
+                .fontWeight(.medium)
+        }
+    }
+    
+    private var color: Color {
+        switch status {
+        case .notDetermined:
+            return .gray
+        case .denied:
+            return .red
+        case .authorized:
+            return .green
+        case .provisional:
+            return .yellow
+        case .ephemeral:
+            return .blue
+        @unknown default:
+            return .gray
+        }
+    }
+    
+    private var text: String {
+        switch status {
+        case .notDetermined:
+            return "未決定"
+        case .denied:
+            return "拒否"
+        case .authorized:
+            return "許可"
+        case .provisional:
+            return "仮許可"
+        case .ephemeral:
+            return "一時"
+        @unknown default:
+            return "不明"
+        }
+    }
+}
+
+struct DetailRow: View {
+    let title: String
+    let value: String
+    
+    var body: some View {
+        HStack {
+            Text(title)
+                .foregroundColor(.secondary)
+            Spacer()
+            Text(value)
+                .fontWeight(.medium)
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    NotificationTestView()
+}


### PR DESCRIPTION
## 概要
Issue #33 の実装: [TASK9-1] 通知権限取得とUNUserNotificationCenter設定

## 変更内容
### 新規作成
- `NotificationManager.swift`: 通知権限管理とローカル通知機能を提供するマネージャークラス
- `Views/Components/NotificationTestView.swift`: 通知機能をテストするためのUI

### 修正
- `EatLockApp.swift`: アプリ起動時に通知マネージャーの初期化と権限リクエストを追加
- `Navigation/NavigationDestination.swift`: 通知テストビューへのナビゲーションルートを追加
- `Navigation/NavigationRouter.swift`: `notificationTest`ケースのIdentifiable実装を追加

### 削除
なし

## 技術詳細
- **フレームワーク**: UNUserNotificationCenter（iOS標準）
- **アーキテクチャ**: シングルトンパターンで`NotificationManager`を実装
- **永続化**: UserDefaultsを使用して権限リクエスト履歴を管理
- **初期化フロー**: アプリ起動時にAI初期化の後に通知初期化を実行
- **エラーハンドリング**: 詳細なログ出力とエラー状態の管理

## 動作確認
- [x] アプリ起動時に通知権限ダイアログが表示される（初回のみ）
- [x] 権限許可/拒否の状態が正しく永続化される
- [x] テスト通知が即時発火される
- [x] 習慣化サポート通知がスケジュールできる
- [x] 設定画面から通知テストビューにアクセス可能
- [x] 権限状態の詳細情報が表示される
- [x] エラー情報が適切に表示される

## 関連Issue
Closes #33

## スクリーンショット（UI変更がある場合）

| Before | After |
|--------|-------|
| 設定画面に通知関連機能なし | 設定画面に「通知テスト」メニューを追加 |
| 通知機能なし | 通知権限管理と各種通知機能を実装 |

## 特記事項
- `NotificationManager`はシングルトンパターンで実装し、アプリ全体から簡単にアクセス可能
- File System Synchronized Root Groupsにより、新規作成ファイルは自動的にプロジェクトに追加済み
- 初回のみ権限リクエストを行い、ユーザーの選択を永続化
- 開発者向けのテストUIを提供し、権限状態の確認とテスト通知の発火が可能
- エラーハンドリングとログ出力により、デバッグとトラブルシューティングを支援